### PR TITLE
Changed small IMU message to use floating point values

### DIFF
--- a/message_definitions/v1.0/rosflight.xml
+++ b/message_definitions/v1.0/rosflight.xml
@@ -45,13 +45,13 @@
         </message>
         <message id="181" name="SMALL_IMU">
             <field type="uint32_t" name="time_boot_us">Measurement timestamp as microseconds since boot</field>
-            <field type="int16_t" name="xacc">Acceleration along X axis</field>
-            <field type="int16_t" name="yacc">Acceleration along Y axis</field>
-            <field type="int16_t" name="zacc">Acceleration along Z axis</field>
-            <field type="int16_t" name="xgyro">Angular speed around X axis</field>
-            <field type="int16_t" name="ygyro">Angular speed around Y axis</field>
-            <field type="int16_t" name="zgyro">Angular speed around Z axis</field>
-            <field type="int16_t" name="temperature">Internal temperature measurement</field>
+            <field type="float" name="xacc">Acceleration along X axis</field>
+            <field type="float" name="yacc">Acceleration along Y axis</field>
+            <field type="float" name="zacc">Acceleration along Z axis</field>
+            <field type="float" name="xgyro">Angular speed around X axis</field>
+            <field type="float" name="ygyro">Angular speed around Y axis</field>
+            <field type="float" name="zgyro">Angular speed around Z axis</field>
+            <field type="float" name="temperature">Internal temperature measurement</field>
         </message>
         <message id="182" name="SMALL_MAG">
             <field type="int16_t" name="xmag">Magnetic field along X axis</field>


### PR DESCRIPTION
This is part of the proposed plan to switch things over to floating point values with SI units as per BYU-MAGICC/ROSflight2#38. Refer to that issue for a conversation on the timing effects of this change.

The final decision hasn't been made yet as far as I'm aware; this pull request is just intended to start the ball rolling.
