### PR TITLE
Status msg

### DIFF
--- a/message_definitions/v1.0/rosflight.xml
+++ b/message_definitions/v1.0/rosflight.xml
@@ -51,12 +51,6 @@
                 <description>Field value4 should be ignored</description>
             </entry>
         </enum>
-        <enum name="ROSFLIGHT_FC_STATUS">
-          <entry value="0x01" name="ROSFLIGHT_STATUS_ARMED"/>
-          <entry value="0x02" name="ROSFLIGHT_STATUS_IN_FAILSAFE"/>
-          <entry value="0x04" name="ROSFLIGHT_STATUS_RC_OVERRIDE"/>
-          <entry value="0x08" name="ROSFLIGHT_STATUS_OFFBOARD_CONTROL_ACTIVE"/>
-        </enum>
         <enum name="ROSFLIGHT_ERROR_CODE">
           <entry value="0x00" name="ROSFLIGHT_ERROR_NONE"/>
           <entry value="0x01" name="ROSFLIGHT_ERROR_INVALID_MIXER"/>
@@ -141,11 +135,13 @@
          <field type="float[8]" name="values"/>
        </message>
        <message id="191" name="ROSFLIGHT_STATUS">
-        <field type="uint8_t" name="status" enum="ROSFLIGHT_FC_STATUS"/>
+        <field type="uint8_t" name="armed"/>
+        <field type="uint8_t" name="failsafe"/>
+        <field type="uint8_t" name="rc_override"/>
         <field type="uint8_t" name="error_code" enum="ROSFLIGHT_ERROR_CODE"/>
         <field type="uint8_t" name="control_mode" enum="OFFBOARD_CONTROL_MODE"/>
-        <field type="uint16_t" name="num_errors"/>
-        <field type="uint16_t" name="loop_time_us"/>
+        <field type="int16_t" name="num_errors"/>
+        <field type="int16_t" name="loop_time_us"/>
       </message>
       <message id="192" name="ROSFLIGHT_VERSION">
         <field type="char[50]" name="version"/>

--- a/message_definitions/v1.0/rosflight.xml
+++ b/message_definitions/v1.0/rosflight.xml
@@ -64,6 +64,10 @@
           <entry value="0x04" name="ROSFLIGHT_ERROR_RC_LOST"/>
           <entry value="0x08" name="ROSFLIGHT_ERROR_UNHEALTHY_ESTIMATOR"/>
         </enum>
+        <enum name="ROSFLIGHT_RANGE_TYPE">
+          <entry value="0x00" name="ROSFLIGHT_RANGE_SONAR"/>
+          <entry value="0x01" name="ROSFLIGHT_RANGE_LIDAR"/>
+        </enum>
     </enums>
     <messages>
         <message id="180" name="OFFBOARD_CONTROL">
@@ -119,10 +123,11 @@
           <field type="float" name="z">z value in the command struct</field>
           <field type="float" name="F">F value in the command struct</field>
         </message>
-       <message id="187" name="SMALL_SONAR">
-         <field type="float" name="range">Range Measurement (m)</field>
-         <field type="float" name="max_range">Max Range (m)</field>
-         <field type="float" name="min_range">Min Range (m)</field>
+       <message id="187" name="SMALL_RANGE">
+          <field type="float" name="type" enum="ROSFLIGHT_RANGE_TYPE">Sensor type</field>
+          <field type="float" name="range">Range Measurement (m)</field>
+          <field type="float" name="max_range">Max Range (m)</field>
+          <field type="float" name="min_range">Min Range (m)</field>
        </message>
        <message id="188" name="ROSFLIGHT_CMD">
          <field type="uint8_t" name="command" enum="ROSFLIHT_CMD"/>
@@ -145,8 +150,5 @@
       <message id="192" name="ROSFLIGHT_VERSION">
         <field type="char[50]" name="version"/>
       </message>
-      <message id="193" name="LIDAR">
-          <field type="float" name="altitude">Calculated Altitude (m)</field>
-        </message>
     </messages>
 </mavlink>

--- a/message_definitions/v1.0/rosflight.xml
+++ b/message_definitions/v1.0/rosflight.xml
@@ -145,5 +145,8 @@
       <message id="192" name="ROSFLIGHT_VERSION">
         <field type="char[50]" name="version"/>
       </message>
+      <message id="193" name="LIDAR">
+          <field type="float" name="altitude">Calculated Altitude (m)</field>
+        </message>
     </messages>
 </mavlink>

--- a/message_definitions/v1.0/rosflight.xml
+++ b/message_definitions/v1.0/rosflight.xml
@@ -65,8 +65,8 @@
           <entry value="0x08" name="ROSFLIGHT_ERROR_UNHEALTHY_ESTIMATOR"/>
         </enum>
         <enum name="ROSFLIGHT_RANGE_TYPE">
-          <entry value="0x00" name="ROSFLIGHT_RANGE_SONAR"/>
-          <entry value="0x01" name="ROSFLIGHT_RANGE_LIDAR"/>
+          <entry value="0" name="ROSFLIGHT_RANGE_SONAR"/>
+          <entry value="1" name="ROSFLIGHT_RANGE_LIDAR"/>
         </enum>
     </enums>
     <messages>
@@ -124,7 +124,7 @@
           <field type="float" name="F">F value in the command struct</field>
         </message>
        <message id="187" name="SMALL_RANGE">
-          <field type="float" name="type" enum="ROSFLIGHT_RANGE_TYPE">Sensor type</field>
+          <field type="uint8_t" name="type" enum="ROSFLIGHT_RANGE_TYPE">Sensor type</field>
           <field type="float" name="range">Range Measurement (m)</field>
           <field type="float" name="max_range">Max Range (m)</field>
           <field type="float" name="min_range">Min Range (m)</field>


### PR DESCRIPTION
Modified the rosflight_status message to now include the armed/failsafe/rc_override booleans expected by rosflight. Removed the ROSFLIGHT_FC_STATUS enum and its corresponding field in the msg since these were redundant with the above booleans. Kept the error code and control_mode enums.